### PR TITLE
Fix onChange binding for season selection

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -321,8 +321,8 @@ struct TVDetailView: View {
                 }
                 .pickerStyle(.menu)
                 .padding(.bottom)
-                .onChange(of: selectedSeason) {
-                    viewModel.fetchEpisodes(for: show.id, season: selectedSeason)
+                .onChange(of: selectedSeason) { newSeason in
+                    viewModel.fetchEpisodes(for: show.id, season: newSeason)
                 }
 
                 ScrollView(.horizontal, showsIndicators: false) {


### PR DESCRIPTION
## Summary
- adjust TVDetailView's `.onChange` closure to use the new season value

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6842680965e88322a1ba86d6e17bfbcc